### PR TITLE
add filter so default images don't get moved if they are not needed

### DIFF
--- a/lib/fileTools.js
+++ b/lib/fileTools.js
@@ -207,7 +207,12 @@ function syncFiles (source, target, options, callback) {
         if (info.isDirectory()) {
           return syncFiles(sourceFile, path.join(target, fileOrDir));
         }
-
+        //check to see if default file show be skipped 
+        if(options.filter){
+            var check  = options.filter(fileOrDir);
+            if (check === false) return
+            
+        }
         // synchronize a single file        
         var targetFile = path.join(target, fileOrDir);
         return syncFile(sourceFile, targetFile);

--- a/lib/fileTools.js
+++ b/lib/fileTools.js
@@ -207,12 +207,15 @@ function syncFiles (source, target, options, callback) {
         if (info.isDirectory()) {
           return syncFiles(sourceFile, path.join(target, fileOrDir));
         }
-        //check to see if default file show be skipped 
-        if(options.filter){
-            var check  = options.filter(fileOrDir);
-            if (check === false) return
-            
+        
+        // check to see if file should be skipped 
+        if (options.filter) {
+          var check = options.filter(fileOrDir);
+          if (check === false) {
+            return;
+          }
         }
+        
         // synchronize a single file        
         var targetFile = path.join(target, fileOrDir);
         return syncFile(sourceFile, targetFile);

--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -99,7 +99,7 @@ function PlatformBase (id, name, packageName, baseDir) {
 
   /**
    * Returns an array of icons files as defined in the manifest. The method assumes that all icons 
-   * are defined as properties of an 'icons' member, for example:
+   * are are square and defined as properties of an 'icons' member, for example:
    *   "icons": {
    *       "30": "/images/smalllogo.png",
    *       "50": "/images/storelogo.png",
@@ -112,8 +112,25 @@ function PlatformBase (id, name, packageName, baseDir) {
   };
   
   /**
-   * Adds an icon file to the manifest. The method assumes that all icons are
-   * defined as properties of an 'icons' member, for example:
+   * Receives the size (e.g. '50x50') of an icon and returns the corresponding icon element 
+   * from the manifest or undefined if not found. The method assumes that all icons 
+   * are square and defined as properties of an 'icons' member, for example:
+   *   "icons": {
+   *       "30": "/images/smalllogo.png",
+   *       "50": "/images/storelogo.png",
+   *       "150": "/images/logo.png"
+   *    }
+   * Platforms should override this method if the manifest icons use a different format.
+   */
+  self.getManifestIcon = function (manifest, size) {
+    // assumes icons are square
+    var dimensions = size.toLowerCase().split('x');    
+    return manifest.icons[dimensions[0]];
+  };
+
+  /**
+   * Adds an icon file with the specified size (e.g. '50x50') to the manifest. The method
+   * assumes that all icons are square and defined as properties of an 'icons' member, for example:
    *   "icons": {
    *       "30": "/images/smalllogo.png",
    *       "50": "/images/storelogo.png",
@@ -141,9 +158,6 @@ function PlatformBase (id, name, packageName, baseDir) {
     var iconList = manifest.icons;
     return Q.resolve().then(function () {
       if (iconList) {
-        // var icons = Array.isArray(iconList) ? 
-        //             iconList.map(function (icon) { return icon.src; }) : 
-        //             Object.keys(iconList).map(function (size) { return manifest.icons[size]; });
         var icons = self.getManifestIcons(manifest);
         
         var downloadTasks = icons.map(function (icon) {
@@ -167,16 +181,13 @@ function PlatformBase (id, name, packageName, baseDir) {
     .then(function () {
       var defaultImagesDir = path.join(self.baseDir, 'assets', 'images');
       return fileTools.syncFiles(defaultImagesDir, imagesDir, {
-          //filter out default images that do not need to be moved over
-          filter:function(file){
-               var x;
-           for(x in manifest.icons){
-                if(file.includes(x)) {
-                    return false
-                }
-          return true
-           }
-           }
+        // filter out default images that do not need to be moved over
+        filter: function (file) {
+          // determine the icon dimensions assuming a convention where 
+          // the file name specifies the icon's size (e.g. '50x50.png')
+          var size = path.basename(file, path.extname(file));
+          return !self.getManifestIcon(manifest, size);
+        }
       }).then(function (files) {        
         files.forEach(function (file) {
           // make path relative to imagesDir

--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -203,7 +203,7 @@ function PlatformBase (id, name, packageName, baseDir) {
           return Q.reject(err);
         }
         
-        self.warn('No default icons were found to copy for the \'' + self.id + '\' platform.');
+        self.debug('No default icons were found to copy for the \'' + self.id + '\' platform.');
       });
     })
     .nodeify(callback);

--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -125,7 +125,7 @@ function PlatformBase (id, name, packageName, baseDir) {
   self.getManifestIcon = function (manifest, size) {
     // assumes icons are square
     var dimensions = size.toLowerCase().split('x');    
-    return manifest.icons[dimensions[0]];
+    return manifest.icons && manifest.icons[dimensions[0]];
   };
 
   /**

--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -166,7 +166,18 @@ function PlatformBase (id, name, packageName, baseDir) {
     // copy default platform icons to replace any missing icons
     .then(function () {
       var defaultImagesDir = path.join(self.baseDir, 'assets', 'images');
-      return fileTools.syncFiles(defaultImagesDir, imagesDir).then(function (files) {        
+      return fileTools.syncFiles(defaultImagesDir, imagesDir, {
+          //filter out default images that do not need to be moved over
+          filter:function(file){
+               var x;
+           for(x in manifest.icons){
+                if(file.includes(x)) {
+                    return false
+                }
+          return true
+           }
+           }
+      }).then(function (files) {        
         files.forEach(function (file) {
           // make path relative to imagesDir
           var filePath = path.relative(imagesDir, file);

--- a/lib/processTools.js
+++ b/lib/processTools.js
@@ -127,7 +127,7 @@ function getCommandPath(currentPath, command) {
     return undefined;
   }
   
-  var testPath = path.join(currentPath, 'node_modules', '.bin', command);
+  var testPath = path.join(currentPath, node_modules, '.bin', command);
   return Q.nfcall(fs.stat, testPath).then(function (fileInfo) {
     if (fileInfo.isFile()) {
       return Q.resolve(testPath);
@@ -137,16 +137,14 @@ function getCommandPath(currentPath, command) {
       return Q.reject(err);
     }
     
-    currentPath = currentPath.substring(0, currentPath.lastIndexOf(path.sep));    
+    currentPath = currentPath.substring(0, currentPath.lastIndexOf(path.sep));
     if (currentPath.indexOf(node_modules) >= 0) {
       if (currentPath.substr(currentPath.length - node_modules.length) === node_modules) {
         currentPath = currentPath.substring(0, currentPath.length - node_modules.length);
-      }
-      
-      return getCommandPath(currentPath, command);    
+      }      
     }
     
-    return undefined;
+    return getCommandPath(currentPath, command);    
   });  
 }
 


### PR DESCRIPTION
Fernando,
  Can you look over this and accept it if you don't see any issues.  This should ad a filter to filter out default images that match images sizes that come from the manifest.
