### PR TITLE
Fallback to name starting with lower case letter.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,7 @@ function sanitizeName (name) {
   while (currentLength > sanitizedName.length);
 
   if (sanitizedName.length === 0) {
-    sanitizedName = 'MyManifoldJSApp';
+    sanitizedName = 'myManifoldJSApp';
   }
 
   return sanitizedName;


### PR DESCRIPTION
The change is done because Android rejects package names starting with upper
case letters.

Fixes #6.
