### PR TITLE
add support for edge extensions

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -40,6 +40,7 @@ module.exports = {
   BASE_MANIFEST_FORMAT: 'w3c',
   CHROME_MANIFEST_FORMAT: 'chromeos',
   FIREFOX_MANIFEST_FORMAT: 'firefox',
-  WINDOWS10_MANIFEST_FORMAT: 'windows10',    
+  WINDOWS10_MANIFEST_FORMAT: 'windows10',
+  EDGE_EXTENSION_FORMAT: 'edgeextension',
   validation: validationConstants
 };

--- a/lib/manifestTools/manifestValidator.js
+++ b/lib/manifestTools/manifestValidator.js
@@ -112,15 +112,18 @@ function runValidationRules(w3cManifestInfo, rules, callback) {
 function applyValidationRules(w3cManifestInfo, platformModules, platforms) {
 
   var allResults = [];
-  
-  // load and run validation rules for "all platforms"
-  var validationRulesDir = path.join(__dirname, 'validationRules');
-  return loadValidationRules(validationRulesDir).then(function (rules) {
-    return runValidationRules(w3cManifestInfo, rules).then(function (results) {
-      allResults.push.apply(allResults, results);
-    });
-  })
-  .then(function () {
+
+  function validateAllPlatforms() {
+    // load and run validation rules for "all platforms"
+    var validationRulesDir = path.join(__dirname, 'validationRules');
+    return loadValidationRules(validationRulesDir).then(function (rules) {
+      return runValidationRules(w3cManifestInfo, rules).then(function (results) {
+        allResults.push.apply(allResults, results);
+      });
+    })
+  };
+
+  function validatePlatform() {
     // run platform-specific validation rules 
     var platformTasks = platformModules.map(function (platform) {
       return platform.getValidationRules(platforms).then(function (rules) {
@@ -131,8 +134,17 @@ function applyValidationRules(w3cManifestInfo, platformModules, platforms) {
     });
 
     return Q.allSettled(platformTasks);
-  })
-  .thenResolve(allResults);  
+  }
+  
+  // Don't run the "All Platform" validattion for Edge Extensions since they are not w3c compliant
+  if (platforms.length === 1 && platforms[0] === constants.EDGE_EXTENSION_FORMAT) {
+    return validatePlatform()
+      .thenResolve(allResults);
+  } else {
+    return validateAllPlatforms()
+      .then(validatePlatform)
+      .thenResolve(allResults);
+  } 
 }
 
 function validateManifest(w3cManifestInfo, platforms, callback) {


### PR DESCRIPTION
Add Edge Extension constant
In the manifest validator, add logic to bypass 'all platform' validation
on edge extensions
