### PR TITLE
Edge Extensions Transform To Required Props

### DIFF
--- a/lib/manifestTools/transformations/edgeextension.js
+++ b/lib/manifestTools/transformations/edgeextension.js
@@ -16,6 +16,8 @@ function convertFromBase (manifestInfo, callback) {
   return callback(undefined, manifestInfo);
 }
 
+var requiredProperties = ['name', 'author', 'version'];
+
 var validRootProperties = ['name', 'author', 'version', 'default_locale', 'description', 'manifest_version', 'icons', 'content_security_policy',
                            'browser_action', 'page_action', 'background', 'commands', 'content_scripts', 'externally_connectable', 'homepage_url',
                            'addressbar', 'options_page', 'permissions', 'optional_permissions', 'web_accessible_resources', 'minimum_edge_version',
@@ -23,13 +25,18 @@ var validRootProperties = ['name', 'author', 'version', 'default_locale', 'descr
 
 function matchFormat (manifestObj) {
   var lowercasePropName;
+  var lowercaseManifestProperties = [];
 
   for (var prop in manifestObj) {
     if (manifestObj.hasOwnProperty(prop)) {
       lowercasePropName = prop.toLowerCase();
-      if (validRootProperties.indexOf(lowercasePropName) === -1 && lowercasePropName.indexOf('_') <= 0) {
+      lowercaseManifestProperties.push(lowercasePropName);
+    }
+  }
+
+  for (var reqProperty in requiredProperties) {
+    if (!lowercaseManifestProperties.indexOf(reqProperty)) {
         return false;
-      }
     }
   }
 


### PR DESCRIPTION
Edge extensions only have 3 required properties and many optional
properties or others that can be ignored. Changing the check from a
whitelist to a required list of manifest properties.
