### PR TITLE
Edge extension platform support

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -44,6 +44,6 @@ module.exports = {
   CHROME_MANIFEST_FORMAT: 'chromeos',
   FIREFOX_MANIFEST_FORMAT: 'firefox',
   WINDOWS10_MANIFEST_FORMAT: 'windows10',
-  EDGE_EXTENSION_FORMAT: 'edgeextension',
+  EDGE_EXTENSION_MANIFEST_FORMAT: 'edgeextension',
   validation: validationConstants
 };

--- a/lib/manifestTools/manifestLoader.js
+++ b/lib/manifestTools/manifestLoader.js
@@ -157,7 +157,7 @@ function writeToFile (manifestInfo, filePath, callback) {
 }
 
 function listAvailableManifestFormats() {
-  return [constants.BASE_MANIFEST_FORMAT, constants.CHROME_MANIFEST_FORMAT];
+  return [constants.BASE_MANIFEST_FORMAT, constants.CHROME_MANIFEST_FORMAT, constants.EDGE_EXTENSION_MANIFEST_FORMAT];
 }
 
 module.exports = {

--- a/lib/manifestTools/manifestValidator.js
+++ b/lib/manifestTools/manifestValidator.js
@@ -136,15 +136,15 @@ function applyValidationRules(w3cManifestInfo, platformModules, platforms) {
     return Q.allSettled(platformTasks);
   }
   
-  // Don't run the "All Platform" validattion for Edge Extensions since they are not w3c compliant
-  if (platforms.length === 1 && platforms[0] === constants.EDGE_EXTENSION_FORMAT) {
-    return validatePlatform()
-      .thenResolve(allResults);
-  } else {
+  // Only run the "All Platform" validations for W3C manifests
+  if (w3cManifestInfo.format === constants.BASE_MANIFEST_FORMAT) {
     return validateAllPlatforms()
       .then(validatePlatform)
       .thenResolve(allResults);
-  } 
+  } else {
+    return validatePlatform()
+      .thenResolve(allResults);
+  }
 }
 
 function validateManifest(w3cManifestInfo, platforms, callback) {


### PR DESCRIPTION
- Run "All platforms" validation only for w3c manifests
- Add "edgeextension" as valid value in the force manifest option
