### PR TITLE
Fixes manifoldjs/manifoldjs#270 & manifoldjs/manifoldjs#262

### DIFF
--- a/lib/manifestTools/manifestCreator/scrapers/display.js
+++ b/lib/manifestTools/manifestCreator/scrapers/display.js
@@ -10,7 +10,7 @@ var display = function(obj, callback) {
   var qqFullScreen = $('[name=x5-fullscreen][content=true]');
   var ucFullScreen = $('meta[name=full-screen][content=yes]');
 
-  var fullscreen = !!$().add(qqFullScreen).add(ucFullScreen).length;
+  var fullscreen = !!$().add(qqFullScreen).add(ucFullScreen).length ? 'fullscreen' : undefined;
 
   //standalone
   var qqStandalone = $('[name=x5-page-mode][content="app"]');
@@ -18,12 +18,10 @@ var display = function(obj, callback) {
   var iosStandalone = $('[name=apple-mobile-web-app-capable][content=yes]');
   var androidStandalone = $('[name=mobile-web-app-capable][content=yes]');
 
-
-  var standalone = !!$().add(qqStandalone).add(ucStandalone).add(iosStandalone).add(androidStandalone).length;
+  var standalone = !!$().add(qqStandalone).add(ucStandalone).add(iosStandalone).add(androidStandalone).length ? 'standalone' : undefined;
 
   //minimal-ui
-  var minimal = !!$('[name=viewport][content*=minimal-ui]').length;
-
+  var minimal = !!$('[name=viewport][content*=minimal-ui]').length ? 'minimal-ui' : undefined;
 
   var _display = fullscreen || standalone || minimal || 'browser';
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "adm-zip": "^0.4.7",
     "ansi": "^0.3.1",
     "async": "^1.5.2",
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.20.0",
     "eslint-config-hapi": "^9.1.0",
     "expect": "^1.20.1",
     "file-type": "^3.8.0",
@@ -50,10 +50,10 @@
     "request": "^2.67.0",
     "semver": "^5.1.0",
     "strip-combining-marks": "^0.1.0",
-    "tld-extract": "^1.0.1",    
+    "tld-extract": "^1.0.1",
     "tv4": "^1.2.7",
     "valid-url": "^1.0.9",
-    "xregexp": "^3.1.1"    
+    "xregexp": "^3.1.1"
   },
   "devDependencies": {
     "blanket": "1.1.6",


### PR DESCRIPTION
Bug Fixes: 
 * Manifest validation fails after resolving the display W3C property (manifoldjs/ManifoldJS#270)
 * Builder chokes on icon creation (manifoldjs/ManifoldJS#262)