### PR TITLE
Correctly resolve icon URLs

### DIFF
--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -266,7 +266,7 @@ function PlatformBase (id, name, packageName, baseDir, extendedCfg) {
       log.debug('Updating icons absolute path to relative path at manifest info...');
       manifest.icons.forEach(function (icon) {
         if (icon.src) {
-          icon.src = (imagesPath + url.parse(icon.src).pathname).replace('//', '/');
+          icon.src = url.resolve(imagesPath, icon.src);
         }
       });
     }


### PR DESCRIPTION
I'm not sure if this fixes the issue, because I couldn't figure out how to write a test for this.

Basically the issue is that if you have a relative path for an icon that points back to the root origin, e.g. `/icon-path.png`, ManifoldJS doesn't correctly resolve it:

![2017-09-19 13_36_11-pwabuilder - microsoft edge](https://user-images.githubusercontent.com/283842/30614296-c75573e0-9d3f-11e7-9385-808e3b1c392b.png)

You can test this with a manifest like:

```json
{
  "content": {
    "name": "My Web Site",
    "icons": [
      {
        "src": "/icon.png",
        "sizes": "48x48",
        "type": "image/png"
      }
    ],
    "start_url": "/some/relative/path",
    "scope": "https://example.com/"
  }
}
```

For the above, the icon should be resolved to `https://example.com/icon`, but instead it's resolved to `https://example.com/some/relative/path/icon.png`.
