### PR TITLE
Add the blank space to the short_name regex sanitization 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ function sanitizeName (name) {
   var sanitizedName = name;
 
   // Remove all invalid characters
-  sanitizedName = sanitizedName.replace(/[^A-Za-z0-9\.]/g, '');
+  sanitizedName = sanitizedName.replace(/[^A-Za-z0-9" "\.]/g, '');
 
   var currentLength;
   do {


### PR DESCRIPTION
Based on the issue https://github.com/pwa-builder/PWABuilder-CLI/issues/305 in PWABuilder-CLI I included the blank space to the sanitization regex. The blank space is allowed according to the Mozilla manifest [documentation](https://developer.mozilla.org/es/docs/Web/Manifest).

![image](https://user-images.githubusercontent.com/26610409/54431253-b1cdb300-4704-11e9-824b-7683f6f400cf.png)
