### PR TITLE
feat: use a modern user agent when scrapping manifest links

### DIFF
--- a/lib/manifestTools/manifestLoader.js
+++ b/lib/manifestTools/manifestLoader.js
@@ -20,6 +20,7 @@ var constants = require('../constants'),
 var manifestCreator = require('./manifestCreator');
 
 // Request settings taken from https://github.com/InternetExplorer/modern.IE-static-code-scan/blob/master/app.js
+// Then the user agent is updated to that of a PWA-capable browser
 var request = request.defaults({
   followAllRedirects: true,
   encoding: null,
@@ -28,7 +29,7 @@ var request = request.defaults({
   headers: {
     'Accept': 'text/html, application/xhtml+xml, */*',
     'Accept-Language': 'en-US,en;q=0.5',
-    'User-Agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)'
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2763.0 Safari/537.36'
   }
 });
 


### PR DESCRIPTION
This PR solves an issue that the PWA Builder is not able to analyse PWAs that check the user agent and return a separate stub page for older browsers not supporting PWA.

This PR makes the PWA builder to use the same user agent that is already used when fetching the manifest file:
https://github.com/pwa-builder/pwabuilder-lib/blob/8355ebd95249241cb90dce03781c85b7e312c133/lib/manifestTools/manifestCreator/index.js#L15