### PR TITLE
adding src mapping for uploaded images to the platformbase

### DIFF
--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -154,7 +154,8 @@ function PlatformBase (id, name, packageName, baseDir, extendedCfg) {
    */
   self.getEmbeddedIconUri = function(manifest, iconFromGetManifestIcons) {
     // in this case getManifestIcons() already returns the uri
-    return iconFromGetManifestIcons.url || iconFromGetManifestIcons;
+    // url doesn't seem to be in use in most of the new manifest information
+    return iconFromGetManifestIcons.url || iconFromGetManifestIcons.src || iconFromGetManifestIcons;
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
the current build path strip out the object and passes the urls or data uris directly as the `iconFromGetManifestIcons`.
However this has an unintended side effect where if the uri is in base64 it doesn't provide a way to pass the icons name. 
The current code in the lib does support this, so we are using it in the msteams manifest path, and this should not affect other code paths. Let me know if there is any problems adding this here, if so we can overwrite this function within the pwabuilder msteams package rather than making the change here.