### PR TITLE
rejectUnauthorized is added as a default configuration for requesting PWA URL for extracting manifest URL

### DIFF
--- a/lib/manifestTools/manifestLoader.js
+++ b/lib/manifestTools/manifestLoader.js
@@ -25,6 +25,8 @@ var request = request.defaults({
   encoding: null,
   gzip: true,
   jar: false,
+  jar: false,
+  rejectUnauthorized: false,
   headers: {
     'Accept': 'text/html, application/xhtml+xml, */*',
     'Accept-Language': 'en-US,en;q=0.5',

--- a/lib/manifestTools/manifestLoader.js
+++ b/lib/manifestTools/manifestLoader.js
@@ -25,7 +25,6 @@ var request = request.defaults({
   encoding: null,
   gzip: true,
   jar: false,
-  jar: false,
   rejectUnauthorized: false,
   headers: {
     'Accept': 'text/html, application/xhtml+xml, */*',


### PR DESCRIPTION
Fixing - Manifest is declared but cannot be reached pwabuilder.com [#751](https://github.com/pwa-builder/PWABuilder/issues/751)