### PR TITLE
correct package lock discrepancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.0.7",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.0.7",
+  "version": "2.1.1",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The root issue deals with semantic versioning.
The version that we have submitted the flatten folder structure changes to is 2.0.7.
The latest semantic version is 2.1.0 which is what pwabuilder-api is targeted to use, to resolve this issue hence moving the version up to 2.1.1 so that the changes reflected in changes since can happen in 2.1.1 and above rather than a lower version