### PR TITLE
appx, windows10 package compatibility

### DIFF
--- a/lib/platformBase.js
+++ b/lib/platformBase.js
@@ -307,7 +307,7 @@ function PlatformBase (id, name, packageName, baseDir, extendedCfg) {
             return self.resolveEmbeddedIcon(manifest, icon, rootDir, imagesDir);
           }
 
-          var iconPath = icon.url || icon;
+          var iconPath = icon.url || icon.src || icon;
           var iconUrl = url.resolve(baseUrl, iconPath);
           var pathname = icon.fileName || url.parse(iconUrl).pathname;
           var iconFilePath = path.join(imagesDir, pathname);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.0.6",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.0.7",
+  "version": "2.1.2",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
the downloadIcons function was causing an issue with the windows10 library did not download manifest icons due to the manifest icon info being passed in the same structure as the nuxt icon list `{ src: "url", generated, fileType, sizes }` rather than the supported two other formats (url string or `{ url: url ... }`

tested compatibility against macos and msteams