### PR TITLE
Make name sanitization step consistent.

### DIFF
--- a/lib/projectBuilder.js
+++ b/lib/projectBuilder.js
@@ -111,7 +111,7 @@ function createApps (w3cManifestInfo, rootDir, platforms, options, href, callbac
   }
 
   // determine the path where the app will be created
-  options.appName = utils.sanitizeName(w3cManifestInfo.content.short_name);
+  options.appName = utils.sanitizeName(w3cManifestInfo.content.short_name.replace(/[^a-zA-Z0-9]/g, '_'));
   var generatedAppDir = path.join(rootDir, options.appName);
 
   // Add timestamp to manifest information for telemetry purposes only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This impacts all manifests with a shortname that has a space in it.
The code that copies over manifests is looking for names where white space is replaced with underscores, whereas the naming function for the initial folder generation just removes them.

Fix for: https://github.com/pwa-builder/PWABuilder/issues/886

This makes it similar to the usage in which is copying the folder. https://github.com/pwa-builder/pwabuilder-api/blob/master/src/services/storage.js#L38