### PR TITLE
check exception cases for validator library

### DIFF
--- a/lib/projectBuilder.js
+++ b/lib/projectBuilder.js
@@ -46,16 +46,14 @@ function validateManifest(w3cManifestInfo, platformModules, platforms) {
       var validationMessage = 'Manifest validation ' + severity + new Array(Math.max(maxLenSeverity - severity.length + 1, 0)).join(' ') + ' - ' + result.description + '(member: ' + result.member + ').';
       if (result.level === validationConstants.levels.suggestion || result.level === validationConstants.levels.warning) {
         log.warn(validationMessage, result.platform);
-      } else if (result.level === validationConstants.levels.error && projectValidation.isExpectedValidationError(result)) {
-        if (projectValidation.isExpectedCase(result, w3cManifestInfo)) {
-          log.warning(validationMessage, result.platform);
+      } else if (result.level === validationConstants.levels.error) {
+        // handle expected errors rather than deeming it as invalid
+        if (projectValidation.isExpectedValidationError(result) && projectValidation.isExpectedCase(result, w3cManifestInfo)) {
+          log.warn('Manifest validation ' + "WARNING" + new Array(Math.max(maxLenSeverity - severity.length + 1, 0)).join(' ') + ' - ' + result.description + '(member: ' + result.member + ').', result.platform);
         } else {
           log.error(validationMessage, result.platform);
           invalidManifest = true;
         }
-      } else if (result.level === validationConstants.levels.error) {
-        log.error(validationMessage, result.platform);
-        invalidManifest = true;
       }
     });
 

--- a/lib/projectBuilder.js
+++ b/lib/projectBuilder.js
@@ -5,16 +5,17 @@ var path = require('path');
 var Q = require('q');
 
 var CustomError = require('./customError'),
-    fileTools = require('./fileTools'),
-    log = require('./log'),
-    manifestTools = require('./manifestTools'),
-    platformTools = require('./platformTools'),
-    projectTools = require('./projectTools'),
-    utils = require('./utils'),
-    constants = require('./constants'),
-    validationConstants = require('./constants').validation;
+  fileTools = require('./fileTools'),
+  log = require('./log'),
+  manifestTools = require('./manifestTools'),
+  platformTools = require('./platformTools'),
+  projectTools = require('./projectTools'),
+  projectValidation = require('./validations').projectValidation,
+  utils = require('./utils'),
+  constants = require('./constants'),
+  validationConstants = require('./constants').validation;
 
-function processPlatformTasks (tasks) {
+function processPlatformTasks(tasks) {
   return Q.allSettled(tasks).then(function (results) {
     var result = results.reduce(function (success, result) {
       if (result.state !== 'fulfilled') {
@@ -28,7 +29,7 @@ function processPlatformTasks (tasks) {
     if (!result) {
       return Q.reject(new Error('One or more platforms could not be generated successfully.'));
     } else {
-      return Q.resolve(results.map(function(result) {
+      return Q.resolve(results.map(function (result) {
         return result.value;
       }));
     }
@@ -42,9 +43,16 @@ function validateManifest(w3cManifestInfo, platformModules, platforms) {
     var maxLenSeverity = 10;
     validationResults.forEach(function (result) {
       var severity = result.level.toUpperCase();
-      var validationMessage = 'Manifest validation ' + severity + new Array(Math.max(maxLenSeverity - severity.length + 1, 0)).join(' ') + ' - ' +  result.description + '(member: ' + result.member + ').';
+      var validationMessage = 'Manifest validation ' + severity + new Array(Math.max(maxLenSeverity - severity.length + 1, 0)).join(' ') + ' - ' + result.description + '(member: ' + result.member + ').';
       if (result.level === validationConstants.levels.suggestion || result.level === validationConstants.levels.warning) {
         log.warn(validationMessage, result.platform);
+      } else if (result.level === validationConstants.levels.error && projectValidation.isExpectedValidationError(result)) {
+        if (projectValidation.isExpectedCase(result, w3cManifestInfo)) {
+          log.warning(validationMessage, result.platform);
+        } else {
+          log.error(validationMessage, result.platform);
+          invalidManifest = true;
+        }
       } else if (result.level === validationConstants.levels.error) {
         log.error(validationMessage, result.platform);
         invalidManifest = true;
@@ -93,7 +101,7 @@ function copyAssets(assets, generatedAppDir, callback) {
   return Q.resolve().nodeify(callback);
 }
 
-function createApps (w3cManifestInfo, rootDir, platforms, options, href, callback) {
+function createApps(w3cManifestInfo, rootDir, platforms, options, href, callback) {
   // validate arguments
   if (arguments.length < 3) {
     return Q.reject(new Error('One or more required arguments are missing.')).nodeify(callback);
@@ -122,47 +130,47 @@ function createApps (w3cManifestInfo, rootDir, platforms, options, href, callbac
     // load the platform modules
     return platformTools.loadPlatforms(platforms);
   })
-  .then(function (platformModules) {
-    // validate the manifest
-    return validateManifest(w3cManifestInfo, platformModules, platforms).thenResolve(platformModules);
-  })
-  .then(function (platformModules) {
-    // generate missing icons
-    return generateImages(w3cManifestInfo, options).thenResolve(platformModules);
-  })
-  .then(function (platformModules) {
-    // create apps for each platform
-    var tasks = platformModules.map(function (platform) {
-      if (platform) {
-        log.debug('Creating the \'' + platform.name + '\' app...');
-        return Q.resolve(generatedAppDir).then(function(generatedAppOutputDir) {
-          return fileTools.mkdirp(generatedAppOutputDir).then(function() {
-            var w3cManifestInfoCopy = JSON.parse(JSON.stringify(w3cManifestInfo));
-            return Q.ninvoke(platform, 'create', w3cManifestInfoCopy, generatedAppOutputDir, options, href).then(function () {
-              log.info('The ' + platform.name + ' app was created successfully!');
-            })
-            .catch(function (err) {
-              return Q.reject(new CustomError('Failed to create the ' + platform.name + ' app.', err));
+    .then(function (platformModules) {
+      // validate the manifest
+      return validateManifest(w3cManifestInfo, platformModules, platforms).thenResolve(platformModules);
+    })
+    .then(function (platformModules) {
+      // generate missing icons
+      return generateImages(w3cManifestInfo, options).thenResolve(platformModules);
+    })
+    .then(function (platformModules) {
+      // create apps for each platform
+      var tasks = platformModules.map(function (platform) {
+        if (platform) {
+          log.debug('Creating the \'' + platform.name + '\' app...');
+          return Q.resolve(generatedAppDir).then(function (generatedAppOutputDir) {
+            return fileTools.mkdirp(generatedAppOutputDir).then(function () {
+              var w3cManifestInfoCopy = JSON.parse(JSON.stringify(w3cManifestInfo));
+              return Q.ninvoke(platform, 'create', w3cManifestInfoCopy, generatedAppOutputDir, options, href).then(function () {
+                log.info('The ' + platform.name + ' app was created successfully!');
+              })
+                .catch(function (err) {
+                  return Q.reject(new CustomError('Failed to create the ' + platform.name + ' app.', err));
+                });
             });
           });
-        });
-      }
+        }
 
-      return Q.resolve();
-    });
+        return Q.resolve();
+      });
 
-    return processPlatformTasks(tasks);
-  })
-  .then(function () {
-    // copy assets to the assets folder
-    return copyAssets(options.assets, generatedAppDir);
-  })
-  // return path to project folder
-  .thenResolve(generatedAppDir)
-  .nodeify(callback);
+      return processPlatformTasks(tasks);
+    })
+    .then(function () {
+      // copy assets to the assets folder
+      return copyAssets(options.assets, generatedAppDir);
+    })
+    // return path to project folder
+    .thenResolve(generatedAppDir)
+    .nodeify(callback);
 }
 
-function packageApps (platforms, dir, options, callback) {
+function packageApps(platforms, dir, options, callback) {
   // validate arguments
   if (arguments.length < 2) {
     return Q.reject(new Error('One or more required arguments are missing.')).nodeify(callback);
@@ -187,14 +195,14 @@ function packageApps (platforms, dir, options, callback) {
       var tasks = platformModules.map(function (platform) {
         if (platform) {
           log.debug('Packaging the \'' + platform.name + '\' app...');
-          return Q.resolve(rootDir).then(function(rootOutputDir) {
+          return Q.resolve(rootDir).then(function (rootOutputDir) {
             return Q.ninvoke(platform, 'package', rootOutputDir, options).then(function (path) {
               log.info('The ' + platform.name + ' app was packaged successfully!');
               return Q.resolve(path);
             })
-            .catch (function (err) {
-              return Q.reject(new CustomError('Failed to package the ' + platform.name + ' app.', err));
-            });
+              .catch(function (err) {
+                return Q.reject(new CustomError('Failed to package the ' + platform.name + ' app.', err));
+              });
           });
         } else {
           return Q.resolve();
@@ -204,10 +212,10 @@ function packageApps (platforms, dir, options, callback) {
       return processPlatformTasks(tasks);
     });
   })
-  .nodeify(callback);
+    .nodeify(callback);
 }
 
-function runApp (platformId, dir, options, callback) {
+function runApp(platformId, dir, options, callback) {
   // validate arguments
   if (arguments.length < 2) {
     return Q.reject(new Error('One or more required arguments are missing.')).nodeify(callback);
@@ -232,7 +240,7 @@ function runApp (platformId, dir, options, callback) {
       if (platformModules && platformModules.length > 0) {
         var platform = platformModules[0];
         log.debug('Launching the \'' + platform.name + '\' app ...');
-        return Q.resolve(rootDir).then(function(rootOutputDir) {
+        return Q.resolve(rootDir).then(function (rootOutputDir) {
           return Q.ninvoke(platform, 'run', rootOutputDir, options).catch(function (err) {
             return Q.reject(new CustomError('Failed to launch the ' + platform.name + ' app.', err));
           });
@@ -242,10 +250,10 @@ function runApp (platformId, dir, options, callback) {
       return Q.resolve();
     });
   })
-  .nodeify(callback);
+    .nodeify(callback);
 }
 
-function openApp (platformId, dir, options, callback) {
+function openApp(platformId, dir, options, callback) {
   // validate arguments
   if (arguments.length < 2) {
     return Q.reject(new Error('One or more required arguments are missing.')).nodeify(callback);
@@ -270,7 +278,7 @@ function openApp (platformId, dir, options, callback) {
       if (platformModules && platformModules.length > 0) {
         var platform = platformModules[0];
         log.debug('Opening the \'' + platform.name + '\' app...');
-        return Q.resolve(rootDir).then(function(rootOutputDir) {
+        return Q.resolve(rootDir).then(function (rootOutputDir) {
           return Q.ninvoke(platform, 'open', rootOutputDir, options).catch(function (err) {
             return Q.reject(new CustomError('Failed to open the ' + platform.name + ' app.', err));
           });
@@ -280,7 +288,7 @@ function openApp (platformId, dir, options, callback) {
       return Q.resolve();
     });
   })
-  .nodeify(callback);
+    .nodeify(callback);
 }
 
 module.exports = {

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -1,7 +1,7 @@
 ﻿'use strict';
 
 var platformTools = require('./platformTools'),
-    manifestTools = require('./manifestTools');
+  manifestTools = require('./manifestTools');
 
 function platformsValid(platforms) {
   var availablePlatforms = platformTools.listPlatforms();
@@ -35,9 +35,36 @@ function manifestFormatValid(format) {
   return availableFormats.indexOf(format.toLowerCase()) >= 0;
 }
 
+function isExpectedValidationError(errorResult) {
+  const checkForPurposeList = errorResult.member.contains("icons") && errorResult.member.contains("purpose")
+
+  return checkForPurposeList
+}
+
+function isExpectedCase(errorResult, w3cManifestInfo) {
+  const errorParams = errorResult.split('/').slice(1) //example: /icons/0/purpose -> ['icons', '0', 'purpose']
+  const isIconsPurpose = errorResult.member.contains("icons") && errorResult.member.contains("purpose")
+
+  if (isIconsPurpose) {
+    const [icons, index, purpose] = errorParams
+
+    return w3cManifestInfo[icons][index][purpose].split(" ").filter(entry => {
+      return (entry === "any" || entry === "maskable" || entry === "monochrome");
+    }).length > 0
+  }
+
+  return false;
+}
+
+
+
 module.exports = {
   platformsValid: platformsValid,
   platformToRunValid: platformToRunValid,
   logLevelValid: logLevelValid,
-  manifestFormatValid: manifestFormatValid
+  manifestFormatValid: manifestFormatValid,
+  projectValidation: {
+    isExpectedValidationError: isExpectedValidationError,
+    isExpectedCase: isExpectedCase,
+  }
 };

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -36,19 +36,19 @@ function manifestFormatValid(format) {
 }
 
 function isExpectedValidationError(errorResult) {
-  const checkForPurposeList = errorResult.member.contains("icons") && errorResult.member.contains("purpose")
+  const checkForPurposeList = errorResult.member.includes("icons") && errorResult.member.includes("purpose")
 
   return checkForPurposeList
 }
 
 function isExpectedCase(errorResult, w3cManifestInfo) {
-  const errorParams = errorResult.split('/').slice(1) //example: /icons/0/purpose -> ['icons', '0', 'purpose']
-  const isIconsPurpose = errorResult.member.contains("icons") && errorResult.member.contains("purpose")
+  const errorParams = errorResult.member.split('/').slice(1) //example: /icons/0/purpose -> ['icons', '0', 'purpose']
+  const isIconsPurpose = errorResult.member.includes("icons") && errorResult.member.includes("purpose")
 
   if (isIconsPurpose) {
     const [icons, index, purpose] = errorParams
 
-    return w3cManifestInfo[icons][index][purpose].split(" ").filter(entry => {
+    return w3cManifestInfo.content[icons][index][purpose].split(" ").filter(entry => {
       return (entry === "any" || entry === "maskable" || entry === "monochrome");
     }).length > 0
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-lib",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
tv4 doesn't handle a list of strings separated by spaces. The schema validator just checks against the values as if they were an enum, hence the change to check if the list has correct outputs.

https://www.w3.org/TR/appmanifest/#purpose-member
https://github.com/pwa-builder/pwabuilder-MacOS/issues/17